### PR TITLE
Fixed Function Headers for `waypointCallback`

### DIFF
--- a/include/waypoint_global_planner/waypoint_global_planner.h
+++ b/include/waypoint_global_planner/waypoint_global_planner.h
@@ -5,6 +5,7 @@
 #include <costmap_2d/costmap_2d_ros.h>
 #include <costmap_2d/costmap_2d.h>
 #include <nav_core/base_global_planner.h>
+#include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <base_local_planner/world_model.h>
 #include <base_local_planner/costmap_model.h>
@@ -60,7 +61,7 @@ class WaypointGlobalPlanner : public nav_core::BaseGlobalPlanner
      * @brief Waypoint callback
      * @param waypoint The received waypoint
      */
-    void waypointCallback(const geometry_msgs::PointStampedConstPtr& waypoint);
+    void waypointCallback(const geometry_msgs::PointStamped::ConstPtr& waypoint);
 
     /**
      * @brief External path callback

--- a/src/waypoint_global_planner.cpp
+++ b/src/waypoint_global_planner.cpp
@@ -69,7 +69,7 @@ bool WaypointGlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start_pos
 }
 
 
-void WaypointGlobalPlanner::waypointCallback(const geometry_msgs::PointStampedConstPtr& waypoint)
+void WaypointGlobalPlanner::waypointCallback(const geometry_msgs::PointStamped::ConstPtr& waypoint)
 {
   if (clear_waypoints_)
   {


### PR DESCRIPTION
This pull request fixes a minor bug which causes `catkin build` / `catkin_make` to fail for ROS Melodic.